### PR TITLE
fix: "Uncaught TypeError: Cannot read property 'remove' of null" error

### DIFF
--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -56,7 +56,7 @@ export const CloseItem = (item) => {
     let position = '.' + item.closest('.noticejs').className.replace('noticejs', '').trim();
     setTimeout(() => {
         if (document.querySelectorAll(position + ' .item').length <= 0) {
-            document.querySelector(position).remove();
+            document.querySelector(position) && document.querySelector(position).remove();
         }
     }, 500);
 }


### PR DESCRIPTION

This error occurs when multiple notices are created at the same time

![chrome_2019-01-09_16-36-16](https://user-images.githubusercontent.com/8065899/50886947-cce22500-142c-11e9-971a-1420782dc1bf.png)